### PR TITLE
fix: update `pico` to `v1.1.4`

### DIFF
--- a/pico/run.sh
+++ b/pico/run.sh
@@ -3,9 +3,18 @@ set -e
 
 mkdir -p ../logs
 
-export CHUNK_SIZE=4194304
-export CHUNK_BATCH_SIZE=32
-export SPLIT_THRESHOLD=1048576
+# configurations for aws 192 CPUs
+# export CHUNK_SIZE=4194304
+# export CHUNK_BATCH_SIZE=32
+# export SPLIT_THRESHOLD=1048576
+
+# configurations for normal machines
+# TODO: need to fix BENCH_RECURSION_MAX_CHUNK_SIZE to `1 << 21` for program reth-20528709:
+# <https://github.com/brevis-network/pico/blob/v1.1.4/vm/src/primitives/consts.rs#L63>
+export CHUNK_SIZE=2097152
+export CHUNK_BATCH_SIZE=4
+export SPLIT_THRESHOLD=32768
+
 export RUST_LOG=info
 export RUSTFLAGS="-C target-cpu=native -C target-feature=+avx512f,+avx512ifma,+avx512vl"
 export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
@@ -14,10 +23,21 @@ export VK_VERIFICATION=true
 PROGRAMS=("fibonacci-300kn" "tendermint" "reth-17106222" "reth-20528709")
 
 pushd pico
+
+# setup gnark for on-chain proving
+cargo build --release --bin gnarkctl
+cp target/release/gnarkctl gnarkctl
+./gnarkctl setup --field kb
+
 for prog in "${PROGRAMS[@]}"; do
   echo "Benchmarking $prog"
   cargo run --profile perf --bin bench --features jemalloc --features nightly-features -- --programs $prog --field kb >../../logs/pico-$prog.log
 done
+
+# release gnark
+./gnarkctl teardown
+rm gnarkctl
+
 popd
 
 echo "pico benchmark complete!"


### PR DESCRIPTION
### Test
2025-06-26T02:31:08.921342Z  INFO ╔═══════════════════════╗
2025-06-26T02:31:08.921350Z  INFO ║  PERFORMANCE SUMMARY  ║
2025-06-26T02:31:08.921359Z  INFO ╚═══════════════════════╝
2025-06-26T02:31:08.921361Z  INFO Time Metrics (wall time)
2025-06-26T02:31:08.921363Z  INFO ----------------------------------------
2025-06-26T02:31:08.921365Z  INFO RISCV:     25s
2025-06-26T02:31:08.921367Z  INFO Recursion Steps:
2025-06-26T02:31:08.921369Z  INFO   CONVERT: 9s
2025-06-26T02:31:08.921370Z  INFO   COMBINE: 10s
2025-06-26T02:31:08.921372Z  INFO   COMPRESS:3s
2025-06-26T02:31:08.921373Z  INFO   EMBED:   13s
2025-06-26T02:31:08.921375Z  INFO   ----------------------------------------
2025-06-26T02:31:08.921376Z  INFO   TOTAL:   36s
2025-06-26T02:31:08.921378Z  INFO ----------------------------------------
2025-06-26T02:31:08.921379Z  INFO EVM:       5s
2025-06-26T02:31:08.921381Z  INFO ----------------------------------------
2025-06-26T02:31:08.921382Z  INFO TOTAL:     1m6s
*Pico Performance Benchmark Results*


| program     | cycles      | riscv_d     | recursion_d | total_d    | success |
|-------------|-------------|-------------|-------------|------------|---------|
| fibonacci-300kn |     3601971 |         25s |         36s |       1m6s | ✅       |
